### PR TITLE
close #178; created python script that order ref_trk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ FPGA/*
 !FPGA/big_core/mif/*
 !FPGA/big_core/de10_lite_big_core.qpf
 !FPGA/big_core/de10_lite_big_core.qsf
+verif/cache/__pycache__

--- a/verif/cache/cache_pp.py
+++ b/verif/cache/cache_pp.py
@@ -4,6 +4,7 @@ import subprocess
 import argparse
 import difflib
 import sys
+import ref_orderer
 
 parser = argparse.ArgumentParser(description= 'get test name from build')
 parser.add_argument('test_name', help='The name of the test to run pp on')
@@ -25,6 +26,7 @@ def print_message(msg):
 MODEL_ROOT = subprocess.check_output('git rev-parse --show-toplevel', shell=True).decode().split('\n')[0]
 os.chdir(MODEL_ROOT)
 
+
 print_message('--------------------------------------------------------')
 print_message("     Cache Post-Process  : "+args.test_name )
 print_message('--------------------------------------------------------')
@@ -35,11 +37,10 @@ base_path = "target/cache/tests"
 file1_path = os.path.join(base_path, args.test_name, "cache_ref_trk.log").replace("\\", "/")
 file2_path = os.path.join(base_path, args.test_name, "cache_ref_gold_trk.log").replace("\\", "/")
 
+#Reorder the ref_trk files by pairs of Req/rsp
+ref_orderer.orderer_func(file1_path)
+ref_orderer.orderer_func(file2_path)
 
-
-# TODO add a section that can reorder the read request & read responses in both ref & ref_gold so it can be compared.
-# you may overwrite the ref_gold_trk.log with the reordered ref_gold_trk.log
-# this is done my first creating a new file and then overwriting the old one with the new one
 
 if os.path.exists(file2_path):
     # Open the two files

--- a/verif/cache/ref_orderer.py
+++ b/verif/cache/ref_orderer.py
@@ -1,0 +1,56 @@
+import os
+import itertools
+
+
+
+def orderer_func(arg1):
+    N = 6
+    input_filename = arg1
+    output_filename = "verif/cache/output.log"
+    temp_filename  = "verif/cache/temp.log"
+
+    # Open input and output files
+    with open(input_filename, 'r') as input_file, open(output_filename, 'w') as output_file:      
+            
+        lines = input_file.readlines()
+        #Write the header
+        for line in lines:
+            if N != 0:
+                N = N-1
+                output_file.write(line)
+
+        while (lines):
+            with open(temp_filename, 'w') as temp_file:
+                # Find the first occurrence of "CORE_RD_REQ"
+                input_file.seek(0) 
+                lines = input_file.readlines()
+                core_rd_req_found = False
+                cache_rd_rsp_found = False
+                for line in lines:
+                    if "CORE_RD_REQ" in line and not core_rd_req_found:
+                        # Write the line to the output file and continue
+                        output_file.write(line)
+                        core_rd_req_found = True
+                #if req and req_found set, simply write to temp        
+                    elif  "CORE_RD_REQ" in line and core_rd_req_found:
+                        temp_file.write(line) 
+                
+                # If req_found is set, find the rsp pair to req 
+                    if "CACHE_RD_RSP" in line and not cache_rd_rsp_found and core_rd_req_found :
+                        # Write the line to the output file and continue
+                        output_file.write(line)
+                        cache_rd_rsp_found = True
+                #if req_found is 0 just write to temp        
+                    elif "CACHE_RD_RSP" in line:     
+                        temp_file.write(line) 
+                    
+            input_file.close()
+            os.remove(input_filename)
+
+            temp_file.close()
+
+            os.rename(temp_filename, input_filename)
+            input_file   = open(input_filename, 'r')
+    input_file.close()
+    os.remove(input_filename)
+    os.rename(output_filename, input_filename)           

--- a/verif/cache/tests/fill_8_tq_entries.sv
+++ b/verif/cache/tests/fill_8_tq_entries.sv
@@ -14,12 +14,12 @@ delay(0); wr_req(20'h10_8_0, 32'h0000_8888, 5'd8); // write miss - send fill
 delay(10);
 //read the data back
 //FIXME - one issue #178 is resolved, change to delay(0) for all
-delay(2); rd_req(20'h10_1_0, 5'd9); // read hit
-delay(2); rd_req(20'h10_2_0, 5'd10); // read hit
-delay(2); rd_req(20'h10_3_0, 5'd11); // read hit
-delay(2); rd_req(20'h10_4_0, 5'd12); // read hit
-delay(2); rd_req(20'h10_5_0, 5'd13); // read hit
-delay(2); rd_req(20'h10_6_0, 5'd14); // read hit
-delay(2); rd_req(20'h10_7_0, 5'd15); // read hit
-delay(2); rd_req(20'h10_8_0, 5'd16); // read hit
+delay(0); rd_req(20'h10_1_0, 5'd9); // read hit
+delay(0); rd_req(20'h10_2_0, 5'd10); // read hit
+delay(0); rd_req(20'h10_3_0, 5'd11); // read hit
+delay(0); rd_req(20'h10_4_0, 5'd12); // read hit
+delay(0); rd_req(20'h10_5_0, 5'd13); // read hit
+delay(0); rd_req(20'h10_6_0, 5'd14); // read hit
+delay(0); rd_req(20'h10_7_0, 5'd15); // read hit
+delay(0); rd_req(20'h10_8_0, 5'd16); // read hit
 


### PR DESCRIPTION
created python script that order ref_trk  and ref_gold_trk file by pairs of req/resp and integrated it to cache_pp to be compare
I wrote a distinct python script that act as a function and imported it in cache_pp.py and calling the function from there.

I thought it was the more effective way because we need to use it twice 
@amichai-bd let me know if you think the way it is integrated to cache_pp is good or you think of another way. 