### PR TITLE
Abd cach rand tests

### DIFF
--- a/source/cache/cache_pipe.sv
+++ b/source/cache/cache_pipe.sv
@@ -270,7 +270,8 @@ always_comb begin
   cache_pipe_lu_q2.set_ways_modified    =   set_ways_modified_q2;
   cache_pipe_lu_q2.hit                  =   |way_tag_match_q2;
   cache_pipe_lu_q2.miss                 =   !(|way_tag_match_q2) && (cache_pipe_lu_q2.lu_valid);
-  cache_pipe_lu_q2.data_array_address   =   {cache_pipe_lu_q2.lu_set , cache_pipe_lu_q2.set_ways_enc_hit};
+  cache_pipe_lu_q2.data_array_address   =   (cache_pipe_lu_q2.lu_op == FILL_LU) ? {cache_pipe_lu_q2.lu_set , set_ways_enc_victim_q2} :
+                                                                                  {cache_pipe_lu_q2.lu_set , way_tag_enc_match_q2}   ;
   cache_pipe_lu_q2.dirty_evict          =  dirty_evict_q2;
 
 end //always_comb
@@ -364,9 +365,9 @@ always_comb begin
     wr_data_cl_q3.data                   =   (cache_pipe_lu_q3.lu_op == FILL_LU)                             ? cache_pipe_lu_q3.cl_data  :
                                              (cache_pipe_lu_q3.lu_op == WR_LU)   && (cache_pipe_lu_q3.hit)   ? data_array_data_q3        : 
                                                                                                             '0; 
-    wr_data_cl_q3.cl_address             =   cache_pipe_lu_q3.data_array_address;
-    wr_data_cl_q3.valid                  =   (cache_pipe_lu_q3.lu_valid &&   
-                                             ((cache_pipe_lu_q3.lu_op == WR_LU)|| (cache_pipe_lu_q3.lu_op == FILL_LU)));
+    wr_data_cl_q3.cl_address             =  cache_pipe_lu_q3.data_array_address;
+    wr_data_cl_q3.valid                  =  (cache_pipe_lu_q3.lu_valid && ((cache_pipe_lu_q3.lu_op == WR_LU) && cache_pipe_lu_q3.hit)) ||
+                                            (cache_pipe_lu_q3.lu_valid && (cache_pipe_lu_q3.lu_op == FILL_LU));
 end
 
 

--- a/verif/cache/cache_pp.py
+++ b/verif/cache/cache_pp.py
@@ -14,10 +14,10 @@ def print_message(msg):
     msg_type = msg.split()[0]
     try:
         color = {
-            '[ERROR]'   : 'red',
-            '[WARNING]' : 'yellow',
-            '[INFO]'    : 'green',
-            '[COMMAND]' : 'cyan',
+            '[PP_ERROR]'   : 'red',
+            '[PP_WARNING]' : 'yellow',
+            '[PP_INFO]'    : 'green',
+            '[PP_COMMAND]' : 'cyan',
         }[msg_type]
     except:
         color = 'blue'
@@ -90,17 +90,17 @@ if os.path.exists(file2_path):
     if num_diffs > 0:
         #print(f"There are {num_diffs} differences between the two files:")
         #print(f"Please refer to" ,colored(output_path,'white',attrs=['bold']), "to see the full diff\n")
-        print_message(f"[WARNING] There are {num_diffs} differences between the two files:")
-        print_message(f"[INFO] Please refer to {output_path} to see the full diff\n")
+        print_message(f"[PP_WARNING] There are {num_diffs} differences between the two files:")
+        print_message(f"[PP_INFO] Please refer to {output_path} to see the full diff\n")
 
     if num_diffs == 0:
-        print(colored("\n[INFO] Post-Process finish succesfuly ",'green',attrs=['bold']))
+        print(colored("\n[PP_INFO] Post-Process finish succesfuly ",'green',attrs=['bold']))
         sys.exit(0)
     else:
-        print_message(f"\n[ERROR] {args.test_name} have failed Post-Process")
+        print_message(f"\n[PP_ERROR] {args.test_name} have failed Post-Process")
         sys.exit(1)
 else: 
-    print_message(f"\n[WARNING] No golden tracker found for test {args.test_name}")
+    print_message(f"\n[PP_WARNING] No golden tracker found for test {args.test_name}")
     sys.exit(0)
 
 

--- a/verif/cache/tb/cache_tasks.vh
+++ b/verif/cache/tb/cache_tasks.vh
@@ -84,8 +84,8 @@ endtask
 //=======================================================
 //=======================================================
 //systemverilog task to create the pull of tags and sets to be used in the test
-task create_addrs_pull(output logic [7:0] tag_pull [NUM_TAG_PULL:0],
-                       output logic [7:0] set_pull [NUM_SET_PULL:0]);
+task create_addrs_pull(output logic [7:0] tag_pull [MAX_NUM_TAG_PULL:0],
+                       output logic [7:0] set_pull [MAX_NUM_SET_PULL:0]);
     int i;
     for (i = 0; i < NUM_TAG_PULL; i = i + 1) begin
         tag_pull[i] = $urandom_range(8'h00, 8'hFF);

--- a/verif/cache/tb/cache_tasks.vh
+++ b/verif/cache/tb/cache_tasks.vh
@@ -1,0 +1,141 @@
+
+//=======================================================
+//=======================================================
+task delay(input int cycles);
+  for(int i =0; i< cycles; i++) begin
+    @(posedge clk);
+  end
+endtask
+
+//=======================================================
+//=======================================================
+task backdoor_cache_load();
+  for(int SET =0; SET< NUM_SET ; SET++) begin
+    for(int WAY =0; WAY< NUM_WAYS; WAY++) begin
+        back_door_entry.tags    [WAY] = WAY + 1000;
+        back_door_entry.valid   [WAY] = 1'b1;
+        back_door_entry.modified[WAY] = 1'b0;
+        back_door_entry.mru     [WAY] = 1'b0;
+    end
+    tag_mem[SET]  = back_door_entry;
+  end
+
+  for(int D_WAY = 0; D_WAY< (SET_ADRS_WIDTH + WAY_WIDTH) ; D_WAY++) begin
+    data_mem[D_WAY]  = 'h5000+D_WAY;
+  end
+    force cache.cache_pipe_wrap.tag_array.mem  = tag_mem;
+    force cache.cache_pipe_wrap.data_array.mem = data_mem;
+    delay(5);
+
+    release cache.cache_pipe_wrap.data_array.mem;
+    release cache.cache_pipe_wrap.tag_array.mem;
+endtask
+
+//=======================================================
+//=======================================================
+task backdoor_fm_load();
+  $display("= backdoor_fm_load start =\n");
+  for(int FM_ADDRESS =0; FM_ADDRESS < NUM_FM_CL ; FM_ADDRESS++) begin
+        back_door_fm_mem[FM_ADDRESS] = FM_ADDRESS + 'hABBA_BABA_0000_1111;
+  end
+    force far_memory_array.mem  = back_door_fm_mem;
+    force cache_ref_model.mem  = back_door_fm_mem;
+    delay(5);
+    release far_memory_array.mem;
+    release cache_ref_model.mem;
+  $display("= backdoor_fm_load done =\n");
+endtask
+
+//=======================================================
+//=======================================================
+task wr_req( input logic [19:0]  address, 
+             input logic [127:0] data ,
+             input logic [4:0]   id );
+    while (stall) begin
+      delay(1); $display("-> stall! cant send write: %h ", address );
+    end
+$display("wr_req: %h , address %h:", id, address);
+    core2cache_req.valid   =  1'b1;
+    core2cache_req.opcode  =  WR_OP;
+    core2cache_req.address =  address;
+    core2cache_req.data    =  data;
+    core2cache_req.reg_id  =  id;
+    delay(1); 
+    core2cache_req     = '0;
+endtask
+
+//=======================================================
+//=======================================================
+task rd_req( input logic [19:0] address,
+             input logic [4:0] id); 
+    while (stall) begin 
+    delay(1);  $display("-> stall! cant send read: %h ", address);
+    end
+$display("rd_req: %h , address %h:", id, address);
+    core2cache_req.valid   =  1'b1;
+    core2cache_req.opcode  =  RD_OP;
+    core2cache_req.address =  address;
+    core2cache_req.reg_id  =  id;
+    delay(1);
+    core2cache_req     = '0;
+endtask
+
+
+//=======================================================
+//=======================================================
+//systemverilog task to create the pull of tags and sets to be used in the test
+task create_addrs_pull(output logic [7:0] tag_pull [NUM_TAG_PULL:0],
+                       output logic [7:0] set_pull [NUM_SET_PULL:0]);
+    int i;
+    for (i = 0; i < NUM_TAG_PULL; i = i + 1) begin
+        tag_pull[i] = $urandom_range(8'h00, 8'hFF);
+        set_pull[i] = $urandom_range(8'h00, 8'hFF);
+    end
+endtask
+
+
+
+//=======================================================
+//=======================================================
+task create_addrs(output logic [19:0] addr);
+    // assign the tag bits to the addr[19:12]
+    // choose random tag from the tag_pull
+    logic [7:0] rand_num;
+    rand_num = $urandom_range(0, NUM_TAG_PULL - 1);
+    addr[19:12] = tag_pull[rand_num];
+    // assign the set bits for the addr[11:4]
+    // choose random set from the set_pull
+    rand_num = $urandom_range(0, NUM_SET_PULL - 1);
+    addr[11:4] = set_pull[rand_num];
+    // assign random offset bits for the addr[3:0]
+    addr[3:2] = $urandom_range(0, 3);
+    addr[1:0] = 2'b0;
+endtask
+
+//=======================================================
+//=======================================================
+task random_wr(); 
+    logic [19:0] addr;
+    logic [31:0] data;
+    logic [4:0]  id;
+    int i;
+    create_addrs(addr);
+    data = $urandom_range(0, 32'hFFFFFFFF);
+    id = $urandom_range(0, 5'd31);
+    wr_req(addr, data, id);
+    i = $urandom_range(MIN_REQ_DELAY, MAX_REQ_DELAY);
+    delay(i);
+endtask
+
+//=======================================================
+//=======================================================
+task random_rd(); 
+    logic [19:0] addr;
+    logic [4:0]  id;
+    int i;
+    create_addrs(addr);
+    id = $urandom_range(0, 5'd31);
+    rd_req(addr, id);
+    i = $urandom_range(MIN_REQ_DELAY, MAX_REQ_DELAY);
+    delay(i);
+endtask

--- a/verif/cache/tb/cache_tb.sv
+++ b/verif/cache/tb/cache_tb.sv
@@ -15,15 +15,18 @@ t_fm_rd_rsp       fm2cache_rd_rsp;
 
 
 //default values - override in test
-parameter int MAX_REQ_DELAY = 20;
-parameter int MIN_REQ_DELAY = 15;
-parameter int NUM_REQ       = 30;
-parameter int RD_RATIO      = 25; //30% read , 70% write
-parameter int NUM_SET_PULL  = 2;
-parameter int NUM_TAG_PULL  = 2;
+int MAX_REQ_DELAY;
+int MIN_REQ_DELAY;
+int NUM_REQ      ;
+int RD_RATIO     ;
+int NUM_SET_PULL ;//Max is MAX_NUM_SET_PULL
+int NUM_TAG_PULL ;//Max is MAX_NUM_TAG_PULL
 
-logic [7:0] tag_pull [NUM_TAG_PULL:0];
-logic [7:0] set_pull [NUM_SET_PULL:0];
+parameter MAX_NUM_SET_PULL  = 50;  //Max is 
+parameter MAX_NUM_TAG_PULL  = 50;
+
+logic [7:0] tag_pull [MAX_NUM_TAG_PULL:0];
+logic [7:0] set_pull [MAX_NUM_SET_PULL:0];
 
 //==================
 //      clk Gen

--- a/verif/cache/tb/cache_tb.sv
+++ b/verif/cache/tb/cache_tb.sv
@@ -12,6 +12,19 @@ t_fm_req          cache2fm_req_q3;
 t_fm_rd_rsp [9:0] samp_fm2cache_rd_rsp;
 t_fm_rd_rsp       fm2cache_rd_rsp;
 
+
+
+//default values - override in test
+parameter int MAX_REQ_DELAY = 20;
+parameter int MIN_REQ_DELAY = 15;
+parameter int NUM_REQ       = 30;
+parameter int RD_RATIO      = 25; //30% read , 70% write
+parameter int NUM_SET_PULL  = 2;
+parameter int NUM_TAG_PULL  = 2;
+
+logic [7:0] tag_pull [NUM_TAG_PULL:0];
+logic [7:0] set_pull [NUM_SET_PULL:0];
+
 //==================
 //      clk Gen
 //==================
@@ -23,16 +36,18 @@ initial begin: clock_gen
 end// clock_gen
 
 t_set_rd_rsp back_door_entry ;
-
+localparam NUM_FM_CL = 2**(SET_ADRS_WIDTH + TAG_WIDTH);
+t_cl back_door_fm_mem   [NUM_FM_CL-1:0];
 logic [SET_WIDTH-1:0] tag_mem   [(2**SET_ADRS_WIDTH)-1:0];
 logic [CL_WIDTH-1:0]  data_mem  [(2**(SET_ADRS_WIDTH + WAY_WIDTH))-1:0];
 
 
 string test_name;
 initial begin : start_test
-    if ($value$plusargs ("STRING=%s", test_name))
+    if ($value$plusargs ("STRING=%s", test_name)) begin
         $display("STRING value %s", test_name);
-$display("================\n     START\n================\n");
+    end
+    $display("================\n     START\n================\n");
             rst= 1'b1;
             core2cache_req     = '0;
 //exit reset
@@ -81,13 +96,16 @@ end
 if(test_name == "rd_b2b_diff_cl") begin
 `include "rd_b2b_diff_cl.sv"
 end
-
+if(test_name == "rand_simple") begin
+`include "rand_simple.sv"
+end
 $display("\n\n================\n     Done\n================\n");
 
 delay(80); $finish;
 end// initial
 
 `include "cache_trk.vh"
+`include "cache_tasks.vh"
 
 cache cache ( //DUT
    .clk                (clk),            //input   logic
@@ -101,79 +119,6 @@ cache cache ( //DUT
    .fm2cache_rd_rsp    (fm2cache_rd_rsp) //input   var t_fm_rd_rsp
 );
 
-task delay(input int cycles);
-  for(int i =0; i< cycles; i++) begin
-    @(posedge clk);
-  end
-endtask
-
-task backdoor_cache_load();
-
-  for(int SET =0; SET< NUM_SET ; SET++) begin
-    for(int WAY =0; WAY< NUM_WAYS; WAY++) begin
-        back_door_entry.tags    [WAY] = WAY + 1000;
-        back_door_entry.valid   [WAY] = 1'b1;
-        back_door_entry.modified[WAY] = 1'b0;
-        back_door_entry.mru     [WAY] = 1'b0;
-    end
-    tag_mem[SET]  = back_door_entry;
-  end
-
-  for(int D_WAY = 0; D_WAY< (SET_ADRS_WIDTH + WAY_WIDTH) ; D_WAY++) begin
-    data_mem[D_WAY]  = 'h5000+D_WAY;
-  end
-    force cache.cache_pipe_wrap.tag_array.mem  = tag_mem;
-    force cache.cache_pipe_wrap.data_array.mem = data_mem;
-    delay(5);
-
-    release cache.cache_pipe_wrap.data_array.mem;
-    release cache.cache_pipe_wrap.tag_array.mem;
-endtask
-
-localparam NUM_FM_CL = 2**(SET_ADRS_WIDTH + TAG_WIDTH);
-t_cl back_door_fm_mem   [NUM_FM_CL-1:0];
-task backdoor_fm_load();
-  $display("= backdoor_fm_load start =\n");
-  for(int FM_ADDRESS =0; FM_ADDRESS < NUM_FM_CL ; FM_ADDRESS++) begin
-        back_door_fm_mem[FM_ADDRESS] = FM_ADDRESS + 'hABBA_BABA_0000_1111;
-  end
-    force far_memory_array.mem  = back_door_fm_mem;
-    force cache_ref_model.mem  = back_door_fm_mem;
-    delay(5);
-    release far_memory_array.mem;
-    release cache_ref_model.mem;
-  $display("= backdoor_fm_load done =\n");
-endtask
-
-task wr_req( input logic [19:0]  address, 
-             input logic [127:0] data ,
-             input logic [4:0]   id );
-    while (stall) begin
-      delay(1); $display("-> stall! cant send write: %h ", address );
-    end
-$display("wr_req: %h , address %h:", id, address);
-    core2cache_req.valid   =  1'b1;
-    core2cache_req.opcode  =  WR_OP;
-    core2cache_req.address =  address;
-    core2cache_req.data    =  data;
-    core2cache_req.reg_id  =  id;
-    delay(1); 
-    core2cache_req     = '0;
-endtask
-
-task rd_req( input logic [19:0] address,
-             input logic [4:0] id); 
-    while (stall) begin 
-    delay(1);  $display("-> stall! cant send read: %h ", address);
-    end
-$display("rd_req: %h , address %h:", id, address);
-    core2cache_req.valid   =  1'b1;
-    core2cache_req.opcode  =  RD_OP;
-    core2cache_req.address =  address;
-    core2cache_req.reg_id  =  id;
-    delay(1);
-    core2cache_req     = '0;
-endtask
 
 //============================
 //          Far Memory ARRAY

--- a/verif/cache/tests/level0
+++ b/verif/cache/tests/level0
@@ -8,3 +8,4 @@ wr_b2b_same_cl.sv
 wr_miss_rd_hit_mb.sv
 wr_miss_rd_hit.sv
 wr_miss_wr_hit.sv
+rand_simple.sv

--- a/verif/cache/tests/rand_simple.sv
+++ b/verif/cache/tests/rand_simple.sv
@@ -1,0 +1,12 @@
+delay(1);  backdoor_fm_load();
+create_addrs_pull(tag_pull, set_pull);
+
+
+// send rd/wr request according to the RD_RATIO parameter
+for(int i = 0; i<NUM_REQ; i++) begin
+    if(RD_RATIO > $urandom_range(0, 100)) begin
+        random_rd();
+    end else begin
+        random_wr();
+    end
+end

--- a/verif/cache/tests/rand_simple.sv
+++ b/verif/cache/tests/rand_simple.sv
@@ -1,6 +1,19 @@
 delay(1);  backdoor_fm_load();
-create_addrs_pull(tag_pull, set_pull);
+//==========================================================
+//  Randomly generate read/write requests
+//==========================================================
+// simple:
+// New request is generated every 20-15 cycles
+// 25% read, 75% write
+// 2 sets , 2 tags 
+MAX_REQ_DELAY = 16; 
+MIN_REQ_DELAY = 15;
+NUM_REQ       = 50;
+RD_RATIO      = 25; //25% read , 75% write
+NUM_SET_PULL  = 2;
+NUM_TAG_PULL  = 2;
 
+create_addrs_pull(tag_pull, set_pull);
 
 // send rd/wr request according to the RD_RATIO parameter
 for(int i = 0; i<NUM_REQ; i++) begin


### PR DESCRIPTION
I enabled the random test.
There are many failures once I try and let the random free.
Currently, constraints are:
``` systemverilog
MAX_REQ_DELAY = 16; 
MIN_REQ_DELAY = 15;
NUM_REQ       = 50;
RD_RATIO      = 25; //25% read , 75% write
NUM_SET_PULL  = 2;
NUM_TAG_PULL  = 2;
````

Try and increase number of tags to 5 - it will fail.
This not expected.. We must ensure we know how to fill a set without data corruption.

Try and reduce the delay to under 12 - it will fail.
This is expected due to us no supporting Read miss stall & re-issue.

So first lets try debug & fix the set "stress" where we have 5 tags hitting the same set forcing swaps in and out of the cache CL from same set
