### PR TITLE
test csr instruction. rd = x0 or rs = x0

### DIFF
--- a/sanity_check.py
+++ b/sanity_check.py
@@ -8,7 +8,7 @@ parser = argparse.ArgumentParser(description="Execute commands from a YAML file.
 parser.add_argument("-yml", "--file", required=True, help="YAML file to process")
 
 # Examples:
-# ./sanity_check.py -test mafia_sanity
+# ./sanity_check.py -yml mafia_sanity
 
 # Parse the command-line arguments
 args = parser.parse_args()

--- a/source/big_core/big_core_pkg.vh
+++ b/source/big_core/big_core_pkg.vh
@@ -111,10 +111,18 @@ typedef struct packed {
     logic [1:0]  csr_op;
     logic [4:0]  csr_rs1;
     logic [11:0] csr_addr;
-    logic [31:0] csr_data_imm;    // TODO - rename csr_data_imm to csr_data when using big_core 
-    logic        csr_imm_bit;
+    logic [31:0] csr_data;     
 } t_csr_inst;
 
+typedef struct packed {
+    logic        csr_wren;
+    logic        csr_rden;
+    logic [1:0]  csr_op;
+    logic [4:0]  csr_rs1;
+    logic [11:0] csr_addr;
+    logic [31:0] csr_data_imm;     
+    logic        csr_imm_bit;
+} t_csr_inst_rrv;
 
 
 typedef enum logic [11:0] {

--- a/source/big_core/big_core_pkg.vh
+++ b/source/big_core/big_core_pkg.vh
@@ -111,7 +111,8 @@ typedef struct packed {
     logic [1:0]  csr_op;
     logic [4:0]  csr_rs1;
     logic [11:0] csr_addr;
-    logic [31:0] csr_data;
+    logic [31:0] csr_data_imm;    // TODO - rename csr_data_imm to csr_data when using big_core 
+    logic        csr_imm_bit;
 } t_csr_inst;
 
 

--- a/source/big_core_rrv/mini_core.sv
+++ b/source/big_core_rrv/mini_core.sv
@@ -106,12 +106,12 @@ logic ReadyQ102H;
 logic ReadyQ103H;
 logic ReadyQ104H;
 logic ReadyQ105H;
-t_ctrl_if   CtrlIf;
-t_ctrl_rf   CtrlRf;
-t_ctrl_exe  CtrlExe;
-t_csr_inst  CtrlCsr;
-t_ctrl_mem1 CtrlMem1;
-t_ctrl_wb   CtrlWb;
+t_ctrl_if      CtrlIf;
+t_ctrl_rf      CtrlRf;
+t_ctrl_exe     CtrlExe;
+t_csr_inst_rrv CtrlCsr;
+t_ctrl_mem1    CtrlMem1;
+t_ctrl_wb      CtrlWb;
 
 
 logic [31:0] DMemWrDataQ103H;

--- a/source/big_core_rrv/mini_core.sv
+++ b/source/big_core_rrv/mini_core.sv
@@ -59,8 +59,8 @@ logic [31:0]        RegRdData1Q101H, PreRegRdData1Q102H, RegRdData1Q102H, RegRdD
 logic [31:0]        RegRdData2Q101H, PreRegRdData2Q102H, RegRdData2Q102H, RegRdData2Q103H;
 logic [31:0]        RegWrDataQ104H, RegWrDataQ105H; 
 logic [31:0]        PostSxDMemRdDataQ105H;
-logic [31:0]        RegRdCsrData1Q101H;    // data to write to CSR
 logic [31:0]        CsrReadDataQ102H;      // data red from CSR
+logic [31:0]        CsrWriteDataQ102H;     // data writen to csr
 
 
 // Control bits
@@ -182,8 +182,6 @@ mini_core_ctrl mini_core_ctrl (
   .CtrlCsr              (CtrlCsr            ), //output
   .CtrlMem1             (CtrlMem1           ), //output
   .CtrlWb               (CtrlWb             ), //output
-  // input data path signals
-  .RegRdCsrData1Q101H   (RegRdCsrData1Q101H ), //input
   // output data path signals
   .ImmediateQ101H       (ImmediateQ101H     ) //output
 );
@@ -203,7 +201,6 @@ mini_core_rf (
   .PcQ102H           (PcQ102H),           // output   
   .ImmediateQ102H    (ImmediateQ102H),    // output
   .RegRdData1Q102H   (RegRdData1Q102H),   // output
-  .RegRdCsrData1Q101H(RegRdCsrData1Q101H),// output
   .RegRdData2Q102H   (RegRdData2Q102H)    // output
 );
 
@@ -246,6 +243,7 @@ mini_core_exe mini_core_exe (
   .RegWrDataQ105H      (RegWrDataQ105H     ),  //  input 
   // output data path
   .AluOutQ102H         (AluOutQ102H        ),  //  output
+  .CsrWriteDataQ102H   (CsrWriteDataQ102H),    // output
   .AluOutQ103H         (AluOutQ103H        ),  //  output
   .PcPlus4Q103H        (PcPlus4Q103H       ),  //  output
   .DMemWrDataQ103H     (DMemWrDataQ103H    )   //  output
@@ -256,9 +254,10 @@ mini_core_csr mini_core_csr (
  .Rst             (Rst),  
  .PcQ102H         (PcQ102H),
  // Inputs from the core
- .CsrInstQ102H    (CtrlCsr), 
- .CsrHwUpdt       ('0),// FIXME: support hardware update for CSR (example: mstatus, mcause, ...)
- .MePc            (),
+ .CsrInstQ102H     (CtrlCsr),
+ .CsrWriteDataQ102H(CsrWriteDataQ102H), 
+ .CsrHwUpdt        ('0),// FIXME: support hardware update for CSR (example: mstatus, mcause, ...)
+ .MePc             (),
  .interrupt_counter_expired (),
  // Outputs to the core
  .CsrReadDataQ102H(CsrReadDataQ102H)

--- a/source/big_core_rrv/mini_core_csr.sv
+++ b/source/big_core_rrv/mini_core_csr.sv
@@ -7,6 +7,7 @@ import common_pkg::*;
     input logic [31:0] PcQ102H,
     // Inputs from the core
     input var t_csr_inst CsrInstQ102H,
+    input logic [31:0] CsrWriteDataQ102H,
     input var t_csr_hw_updt CsrHwUpdt, // 32-bit data to be written into the CSR
     // Outputs to the core
     output logic [31:0] MePc, // 32-bit data read from the CSR
@@ -24,12 +25,17 @@ logic        csr_wren;
 logic        csr_rden;
 logic [1:0]  csr_op;
 logic [11:0] csr_addr;
+logic [31:0] csr_data_imm;
+logic        csr_imm_bit;
+assign csr_wren     = CsrInstQ102H.csr_wren;
+assign csr_rden     = CsrInstQ102H.csr_rden;
+assign csr_addr     = CsrInstQ102H.csr_addr;
+assign csr_data_imm = CsrInstQ102H.csr_data_imm;
+assign csr_op       = CsrInstQ102H.csr_op;
+assign csr_imm_bit  = CsrInstQ102H.csr_imm_bit; 
+
 logic [31:0] csr_data;
-assign csr_wren = CsrInstQ102H.csr_wren;
-assign csr_rden = CsrInstQ102H.csr_rden;
-assign csr_addr = CsrInstQ102H.csr_addr;
-assign csr_data = CsrInstQ102H.csr_data;
-assign csr_op   = CsrInstQ102H.csr_op;
+assign csr_data = (csr_imm_bit) ? csr_data_imm : CsrWriteDataQ102H;
 
 logic csr_cycle_low_overflow;
 always_comb begin

--- a/source/big_core_rrv/mini_core_csr.sv
+++ b/source/big_core_rrv/mini_core_csr.sv
@@ -6,7 +6,7 @@ import common_pkg::*;
     input logic Rst,
     input logic [31:0] PcQ102H,
     // Inputs from the core
-    input var t_csr_inst CsrInstQ102H,
+    input var t_csr_inst_rrv CsrInstQ102H,
     input logic [31:0] CsrWriteDataQ102H,
     input var t_csr_hw_updt CsrHwUpdt, // 32-bit data to be written into the CSR
     // Outputs to the core

--- a/source/big_core_rrv/mini_core_ctrl.sv
+++ b/source/big_core_rrv/mini_core_ctrl.sv
@@ -36,8 +36,6 @@ import common_pkg::*;
     output var t_csr_inst   CtrlCsr,
     output var t_ctrl_mem1  CtrlMem1,
     output var t_ctrl_wb    CtrlWb,
-    // input data path signals
-    input logic [31:0]      RegRdCsrData1Q101H,
     // output data path signals
     output  logic [31:0] ImmediateQ101H 
 );
@@ -140,13 +138,13 @@ assign CtrlQ101H.RegSrc1          = InstructionQ101H[19:15];
 assign CtrlQ101H.RegSrc2          = InstructionQ101H[24:20];
 
 // CSR Control Signals
-assign CsrInstQ101H.csr_wren  = (OpcodeQ101H == SYSCAL) && !(((Funct3Q101H[1:0] == 2'b11) || (Funct3Q101H[1:0] == 2'b01)) && (CtrlQ101H.RegSrc1 =='0 ));  
-assign CsrInstQ101H.csr_rden  = (OpcodeQ101H == SYSCAL) && !((Funct3Q101H[1:0]==2'b01 ) && (CtrlQ101H.RegDst =='0 ));
-assign CsrInstQ101H.csr_op    = InstructionQ101H[13:12];
-assign CsrInstQ101H.csr_rs1   = CtrlQ101H.RegSrc1;
-assign CsrInstQ101H.csr_addr  = InstructionQ101H[31:20];
-assign CsrInstQ101H.csr_data  = InstructionQ101H[14] ? {27'h0, CtrlQ101H.RegSrc1} : RegRdCsrData1Q101H;   
-//assign CsrInstQ101H.SelCsrWb  = CsrInstQ101H.csr_rden;   
+assign CsrInstQ101H.csr_wren     = (OpcodeQ101H == SYSCAL) && !(((Funct3Q101H[1:0] == 2'b11) || (Funct3Q101H[1:0] == 2'b01)) && (CtrlQ101H.RegSrc1 =='0 ));  
+assign CsrInstQ101H.csr_rden     = (OpcodeQ101H == SYSCAL) && !((Funct3Q101H[1:0]==2'b01 ) && (CtrlQ101H.RegDst =='0 ));
+assign CsrInstQ101H.csr_op       = InstructionQ101H[13:12];
+assign CsrInstQ101H.csr_rs1      = CtrlQ101H.RegSrc1;
+assign CsrInstQ101H.csr_addr     = InstructionQ101H[31:20];
+assign CsrInstQ101H.csr_data_imm = {27'h0, CtrlQ101H.RegSrc1}; 
+assign CsrInstQ101H.csr_imm_bit  = InstructionQ101H[14];  
 
 logic ebreak_was_calledQ101H; 
 assign ebreak_was_calledQ101H = (InstructionQ101H == 32'b000000000001_00000_000_00000_1110011);

--- a/source/big_core_rrv/mini_core_ctrl.sv
+++ b/source/big_core_rrv/mini_core_ctrl.sv
@@ -30,12 +30,12 @@ import common_pkg::*;
     output  logic        ReadyQ104H,
     output  logic        ReadyQ105H,
     // output ctrl signals
-    output var t_ctrl_if    CtrlIf,
-    output var t_ctrl_rf    CtrlRf,
-    output var t_ctrl_exe   CtrlExe,
-    output var t_csr_inst   CtrlCsr,
-    output var t_ctrl_mem1  CtrlMem1,
-    output var t_ctrl_wb    CtrlWb,
+    output var t_ctrl_if      CtrlIf,
+    output var t_ctrl_rf      CtrlRf,
+    output var t_ctrl_exe     CtrlExe,
+    output var t_csr_inst_rrv CtrlCsr,
+    output var t_ctrl_mem1    CtrlMem1,
+    output var t_ctrl_wb      CtrlWb,
     // output data path signals
     output  logic [31:0] ImmediateQ101H 
 );
@@ -76,7 +76,7 @@ logic PreValidInstQ104H, ValidInstQ104H;
 logic PreValidInstQ105H, ValidInstQ105H;
 
 t_mini_ctrl CtrlQ101H, CtrlQ102H, CtrlQ103H, CtrlQ104H, CtrlQ105H;
-t_csr_inst CsrInstQ101H, CsrInstQ102H;  
+t_csr_inst_rrv CsrInstQ101H, CsrInstQ102H;  
 logic CoreFreeze;
 assign CoreFreeze = !DMemReady;
 // Load and Ctrl hazard detection

--- a/source/big_core_rrv/mini_core_ctrl.sv
+++ b/source/big_core_rrv/mini_core_ctrl.sv
@@ -138,7 +138,7 @@ assign CtrlQ101H.RegSrc1          = InstructionQ101H[19:15];
 assign CtrlQ101H.RegSrc2          = InstructionQ101H[24:20];
 
 // CSR Control Signals
-assign CsrInstQ101H.csr_wren     = (OpcodeQ101H == SYSCAL) && !(((Funct3Q101H[1:0] == 2'b11) || (Funct3Q101H[1:0] == 2'b01)) && (CtrlQ101H.RegSrc1 =='0 ));  
+assign CsrInstQ101H.csr_wren     = (OpcodeQ101H == SYSCAL) && !(((Funct3Q101H[1:0] == 2'b11) || (Funct3Q101H[1:0] == 2'b10)) && (CtrlQ101H.RegSrc1 =='0 ));  
 assign CsrInstQ101H.csr_rden     = (OpcodeQ101H == SYSCAL) && !((Funct3Q101H[1:0]==2'b01 ) && (CtrlQ101H.RegDst =='0 ));
 assign CsrInstQ101H.csr_op       = InstructionQ101H[13:12];
 assign CsrInstQ101H.csr_rs1      = CtrlQ101H.RegSrc1;

--- a/source/big_core_rrv/mini_core_ctrl.sv
+++ b/source/big_core_rrv/mini_core_ctrl.sv
@@ -251,7 +251,6 @@ assign CtrlExe.SelAluPcQ102H = CtrlQ102H.SelAluPc;
 assign CtrlExe.SelAluImmQ102H= CtrlQ102H.SelAluImm;
 
 // Execute Control Signals for Csr
-//assign CtrlCsr.csr_rden = CsrInstQ102H.csr_rden;
 assign CtrlCsr = CsrInstQ102H;
 
 // Memory access1 Control Signals

--- a/source/big_core_rrv/mini_core_exe.sv
+++ b/source/big_core_rrv/mini_core_exe.sv
@@ -19,8 +19,8 @@ import common_pkg::*;
     //===================
     // Input Control Signals
     //===================
-    input  var t_ctrl_exe   Ctrl,
-    input  var t_csr_inst   CtrlCsr,
+    input  var t_ctrl_exe       Ctrl,
+    input  var t_csr_inst_rrv   CtrlCsr,
     input  logic        ReadyQ103H,
     //===================
     // Output Control Signals

--- a/source/big_core_rrv/mini_core_exe.sv
+++ b/source/big_core_rrv/mini_core_exe.sv
@@ -43,6 +43,7 @@ import common_pkg::*;
     // output data path
     //===================
     output logic [31:0] AluOutQ102H,
+    output logic [31:0] CsrWriteDataQ102H, 
     output logic [31:0] AluOutQ103H,
     output logic [31:0] PcPlus4Q103H,
     output logic [31:0] DMemWrDataQ103H
@@ -86,6 +87,8 @@ assign RegRdData2Q102H = Hazard1Data2Q102H ? AluOutQ103H       : // Rd 102 After
                          Hazard2Data2Q102H ? AluOutQ103H       : // Rd 102 After Wr 104
                          Hazard3Data2Q102H ? RegWrDataQ105H    : // Rd 102 After Wr 105 
                                              PreRegRdData2Q102H; // Common Case - No Hazard
+ 
+assign CsrWriteDataQ102H = RegRdData1Q102H; // input data to csr
 
 // End Take care to data hazard
 assign AluIn1Q102H = Ctrl.SelAluPcQ102H  ? PcQ102H          : RegRdData1Q102H;

--- a/source/big_core_rrv/mini_core_rf.sv
+++ b/source/big_core_rrv/mini_core_rf.sv
@@ -28,7 +28,6 @@ import common_pkg::*;
     output logic [31:0] PcQ102H,
     output logic [31:0] ImmediateQ102H,
     output logic [31:0] RegRdData1Q102H,
-    output logic [31:0] RegRdCsrData1Q101H,
     output logic [31:0] RegRdData2Q102H
 );
 
@@ -48,8 +47,6 @@ assign MatchRd1AftrWrQ101H = (Ctrl.RegSrc1Q101H == Ctrl.RegDstQ105H) && (Ctrl.Re
 assign RegRdData1Q101H = (Ctrl.RegSrc1Q101H == 5'b0) ? 32'b0                      : // Reading from Register[0] should result in '0
                          MatchRd1AftrWrQ101H         ? RegWrDataQ105H             : // forwards WrDataQ105H -> RdDataQ101H
                                                        Register[Ctrl.RegSrc1Q101H]; // Common Case - reading from Register file
-
-assign RegRdCsrData1Q101H = RegRdData1Q101H;
 
 assign MatchRd2AftrWrQ101H = (Ctrl.RegSrc2Q101H == Ctrl.RegDstQ105H) && (Ctrl.RegWrEnQ105H);
 assign RegRdData2Q101H = (Ctrl.RegSrc2Q101H == 5'b0) ? 32'b0                      : // Reading from Register[0] should result in '0 

--- a/verif/big_core_rrv/tb/big_core_rrv_csr_tb.sv
+++ b/verif/big_core_rrv/tb/big_core_rrv_csr_tb.sv
@@ -1,0 +1,194 @@
+//-----------------------------------------------------------------------------
+// Title            : core tb
+// Project          : big_core_rrv. 6 stage pipeline
+//-----------------------------------------------------------------------------
+// File             : core_tb.sv
+// Original Author  : Amichai Ben-David
+// Code Owner       : 
+// Created          : 10/2022
+//-----------------------------------------------------------------------------
+// Description :
+// simple test bench
+// (1) generate the clock & rst. 
+// (2) load backdoor the I_MEM & D_MEM.
+// (3) End the test when the ebrake command is executed
+//-----------------------------------------------------------------------------
+
+
+`include "macros.sv"
+
+
+module big_core_rrv_tb  ;
+import common_pkg::*;
+logic        Clk;
+logic        Rst;
+logic [31:0] PcQ100H;
+logic [31:0] Instruction;
+logic [31:0] DMemAddress;
+logic [31:0] DMemData   ;
+logic [3:0]  DMemByteEn ;
+logic        DMemWrEn   ;
+logic        DMemRdEn   ;
+logic [31:0] DMemRdRspData;
+logic  [7:0] IMem     [I_MEM_SIZE_MINI + I_MEM_OFFSET_MINI - 1 : I_MEM_OFFSET_MINI];
+logic  [7:0] DMem     [D_MEM_SIZE_MINI + D_MEM_OFFSET_MINI - 1 : D_MEM_OFFSET_MINI];
+
+
+string test_name;
+
+// ========================
+// clock gen
+// ========================
+initial begin: clock_gen
+    forever begin
+        #5 Clk = 1'b0;
+        #5 Clk = 1'b1;
+    end //forever
+end//initial clock_gen
+
+// ========================
+// reset generation
+// ========================
+initial begin: reset_gen
+     Rst = 1'b1;
+#100 Rst = 1'b0;
+end: reset_gen
+
+
+`MAFIA_DFF(IMem, IMem, Clk)
+`MAFIA_DFF(DMem, DMem, Clk)
+
+integer file;
+initial begin: test_seq
+    if ($value$plusargs ("STRING=%s", test_name))
+        $display("STRING value %s", test_name);
+    //======================================
+    //load the program to the DUT & reference model
+    //======================================
+    // Make sure inst_mem.sv exists
+    file = $fopen({"../../../target/big_core_rrv/tests/",test_name,"/gcc_files/inst_mem.sv"}, "r");
+    if (!file) begin
+        $error("the file: ../../../target/big_core_rrv/tests/%s/gcc_files/inst_mem.sv does not exist", test_name);
+        $display("ERROR: inst_mem.sv file does not exist");
+        $finish;
+    end
+    $readmemh({"../../../target/big_core_rrv/tests/",test_name,"/gcc_files/inst_mem.sv"} , IMem);
+    force mini_core_top.mini_mem_wrap.i_mem.mem = IMem; //backdoor to actual memory
+    //load the data to the DUT & reference model 
+    file = $fopen({"../../../target/big_core_rrv/tests/",test_name,"/gcc_files/data_mem.sv"}, "r");
+    if (file) begin
+        $fclose(file);
+        $readmemh({"../../../target/big_core_rrv/tests/",test_name,"/gcc_files/data_mem.sv"} , DMem);
+        force mini_core_top.mini_mem_wrap.d_mem.mem = DMem; //backdoor to actual memory
+        #10
+        release mini_core_top.mini_mem_wrap.d_mem.mem;
+    end
+    
+    //================================
+    // run until ebreak is found
+    //===============================
+    begin wait(mini_core_top.mini_core.mini_core_ctrl.ebreak_was_calledQ101H == 1'b1);
+       $display("ebreak was called");
+       $finish();
+    end
+   
+end // test_seq
+
+parameter V_TIMEOUT = 100000;
+parameter MINI_RF_NUM_MSB = 31; // For RV32E override this to 15
+initial begin: detect_timeout
+    //=======================================
+    // timeout
+    //=======================================
+    #V_TIMEOUT 
+    $error("test ended with timeout");
+    $display("ERROR: No data integrity running - try to increase the timeout value");
+    $finish;
+end
+
+
+t_tile_id local_tile_id;
+logic        InFabricValidQ503H  ; 
+logic        OutFabricValidQ505H ;
+t_tile_trans InFabricQ503H ; 
+t_tile_trans [2:0] ShiftInFabric ; 
+logic        [2:0] ShiftInFabricValid ; 
+t_tile_trans OutFabricQ505H ;
+
+logic  [7:0] TILE33_DMem      [D_MEM_SIZE_MINI + D_MEM_OFFSET_MINI - 1 : D_MEM_OFFSET_MINI];
+logic  [7:0] next_TILE33_DMem [D_MEM_SIZE_MINI + D_MEM_OFFSET_MINI - 1 : D_MEM_OFFSET_MINI];
+`MAFIA_DFF(TILE33_DMem, next_TILE33_DMem, Clk)
+
+logic [31:0] next_test;
+logic [31:0] test;
+`MAFIA_DFF(test, next_test, Clk)
+always_comb begin
+    next_TILE33_DMem = TILE33_DMem;
+    next_test = test;
+    if (OutFabricValidQ505H) begin
+        if (OutFabricQ505H.opcode == WR) begin
+            next_TILE33_DMem[OutFabricQ505H.address[23:0]+0] = OutFabricQ505H.data[7:0];
+            next_TILE33_DMem[OutFabricQ505H.address[23:0]+1] = OutFabricQ505H.data[15:8];
+            next_TILE33_DMem[OutFabricQ505H.address[23:0]+2] = OutFabricQ505H.data[23:16];
+            next_TILE33_DMem[OutFabricQ505H.address[23:0]+3] = OutFabricQ505H.data[31:24];
+        end
+    end
+end
+
+logic [31:0] RdDataData;
+assign RdDataData[7:0]   = TILE33_DMem[OutFabricQ505H.address[23:0]+0];
+assign RdDataData[15:8]  = TILE33_DMem[OutFabricQ505H.address[23:0]+1];
+assign RdDataData[23:16] = TILE33_DMem[OutFabricQ505H.address[23:0]+2];
+assign RdDataData[31:24] = TILE33_DMem[OutFabricQ505H.address[23:0]+3];
+
+assign ShiftInFabricValid[0] = OutFabricValidQ505H && (OutFabricQ505H.opcode == RD);
+// Set the target address to the requestor id (This is the Read response address)
+always_comb begin 
+    ShiftInFabric[0] = '0;
+    if (OutFabricValidQ505H && OutFabricQ505H.opcode == RD) begin
+        ShiftInFabric[0].address[31:0]         = {local_tile_id,OutFabricQ505H.address[23:0]};
+        ShiftInFabric[0].opcode                = RD_RSP;
+        ShiftInFabric[0].data                  = (OutFabricQ505H.opcode==RD) ? RdDataData : '0;
+        ShiftInFabric[0].requestor_id          = OutFabricQ505H.address[31:0];
+        ShiftInFabric[0].next_tile_fifo_arb_id = OutFabricQ505H.next_tile_fifo_arb_id;
+    end
+end
+`MAFIA_DFF(ShiftInFabric[2:1],      ShiftInFabric[1:0],      Clk)
+`MAFIA_DFF(ShiftInFabricValid[2:1], ShiftInFabricValid[1:0], Clk)
+assign InFabricQ503H        = ShiftInFabric[2];
+assign InFabricValidQ503H   = ShiftInFabricValid[2];
+// DUT instance mini_core 
+assign  local_tile_id = 8'h2_2;
+mini_core_top
+#( .RF_NUM_MSB(MINI_RF_NUM_MSB) )    
+mini_core_top (
+.Clock               (Clk),
+.Rst                 (Rst),
+.local_tile_id       (local_tile_id),
+//============================================
+//      fabric interface
+//============================================
+ .InFabricValidQ503H    (InFabricValidQ503H),// input  logic        F2C_ReqValidQ503H     ,
+ .InFabricQ503H         (InFabricQ503H),// input  t_opcode     F2C_ReqOpcodeQ503H    ,
+ .mini_core_ready       (),  // output  logic  mini_core_ready       ,
+ //
+ .OutFabricQ505H        (OutFabricQ505H),  // output t_rdata      F2C_RspDataQ504H      ,
+ .OutFabricValidQ505H   (OutFabricValidQ505H),  // output logic        F2C_RspValidQ504H
+ .fab_ready             (5'b11111)   // input  t_fab_ready  fab_ready 
+);      
+
+
+rv32i_ref
+# (
+    .I_MEM_LSB (I_MEM_OFFSET_MINI),
+    .I_MEM_MSB (I_MEM_MSB_MINI),
+    .D_MEM_LSB (D_MEM_OFFSET_MINI),
+    .D_MEM_MSB (D_MEM_MSB_MINI)
+)  rv32i_ref (
+.clk    (Clk),
+.rst    (Rst),
+.run    (1'b1) // FIXME - set the RUN only when the mini_core DUT is retiring the instruction.
+               // every time the run is set, the next instruction is executed
+);
+endmodule //mini_core_tb
+

--- a/verif/big_core_rrv/tests/alive_csr.c
+++ b/verif/big_core_rrv/tests/alive_csr.c
@@ -16,17 +16,17 @@ int main()  {
     int misa_csr_value = 30;
     asm volatile ("csrw 0x301, %0" : : "r" (misa_csr_value)); // pseudiInstr: csrw csr, rs. baseInst:  csrrw x0, csr, rs 
 
-    //set bits in CSR in offset 0x009 the value 0x1b - should have the value of 0x1f
+    //set bits in CSR in offset 0x009 the value 0x1b
     asm volatile ("csrs 0x009, 0x1b");    // pseudoInst: csrsi csr, imm. baseInst: csrrsi x0, csr, imm
     
-    //clear bits in CSR in offset 0x009 the value 0x4 - should have the value of 0x4
+    //clear bits in CSR in offset 0x009 the value 0x4
     asm volatile ("csrc 0x009, 0x1b");    // pseudoInst: csrci csr, imm. baseInst: csrrci x0, csr, imm
 
-    //set CSR in offset 0x301 using value 63 - should have the value of 0x3f
+    //set CSR in offset 0x301 using value 63
     int set_misa_csr = 63;
     asm volatile ("csrs 0x301, %0" : : "r" (set_misa_csr)); // pseudiInstr: csrs csr, rs. baseInst: csrrs x0, csr, rs 
 
-    //clear CSR in offset 0x301 using value 11 - should have the value of 0x14 (use only the first inst with misa)
+    //clear CSR in offset 0x301 using value 11 
     int clear_misa_csr = 11;
     asm volatile ("csrc 0x301, %0" : : "r" (clear_misa_csr)); // pseudiInstr: csrc csr, rs. baseInst: csrrc x0, csr, rs 
 
@@ -40,6 +40,13 @@ int main()  {
     asm volatile ("csrrsi %0, 0x009, 0x1b" :  : "r" (previous_value));
     asm volatile ("csrrci %0, 0x009, 0x1b" :  : "r" (previous_value));
 
+    /*** special cases from spec involving x0 ****
+    // test them using assemnbly file
+    csrwi	vxsat,7
+    csrrw	x1,vxsat,x0
+    csrwi	vxsat,7
+    csrwi	vxsat,0
+    **********************************************/
     return 0;
 }  
 

--- a/verif/big_core_rrv/tests/alive_csr.c
+++ b/verif/big_core_rrv/tests/alive_csr.c
@@ -24,11 +24,22 @@ int main()  {
 
     //set CSR in offset 0x301 using value 63 - should have the value of 0x3f
     int set_misa_csr = 63;
-     asm volatile ("csrs 0x301, %0" : : "r" (set_misa_csr)); // pseudiInstr: csrs csr, rs. baseInst: csrrs x0, csr, rs 
+    asm volatile ("csrs 0x301, %0" : : "r" (set_misa_csr)); // pseudiInstr: csrs csr, rs. baseInst: csrrs x0, csr, rs 
 
     //clear CSR in offset 0x301 using value 11 - should have the value of 0x14 (use only the first inst with misa)
     int clear_misa_csr = 11;
     asm volatile ("csrc 0x301, %0" : : "r" (clear_misa_csr)); // pseudiInstr: csrc csr, rs. baseInst: csrrc x0, csr, rs 
+
+    int new_value = 20;
+    int previous_value;
+    asm volatile ("csrrw %0, 0x009, %1" : "=r" (previous_value) : "r" (new_value));
+    asm volatile("csrrw %0, 0x009, %1" : "+r" (previous_value) : "r" (new_value));
+    asm volatile ("csrrs %0, 0x009, %1" : "+r" (previous_value) : "r" (new_value));
+    asm volatile ("csrrc %0, 0x009, %1" : "+r" (previous_value) : "r" (new_value));
+    asm volatile ("csrrwi %0, 0x009, 0x1b" :  : "r" (previous_value));
+    asm volatile ("csrrsi %0, 0x009, 0x1b" :  : "r" (previous_value));
+    asm volatile ("csrrci %0, 0x009, 0x1b" :  : "r" (previous_value));
+
     return 0;
 }  
 

--- a/verif/big_core_rrv/tests/alive_csr.c
+++ b/verif/big_core_rrv/tests/alive_csr.c
@@ -1,0 +1,34 @@
+//------------------------------------------------------------
+// Description :
+// This program is a basic sanity test for the csr
+//------------------------------------------------------------
+
+int main()  {  
+ 
+    //write to CSR in offset 0x009 the value 0x7
+    asm volatile ("csrw 0x009, 0x7");   // pseudoInst: csrwi csr, imm. baseInst: csrrw x0, csr, rs
+
+    // read CSR in offset 0x009  - should have the value 7
+    int scratchpad_csr_value;
+    asm volatile ("csrr %0, 0x009" : "=r" (scratchpad_csr_value));  //pseudoInst: csrr rd, csr. baseInst:  csrrs rd, csr, x0 
+
+    //write to CSR in offset 0x301 the value of 30
+    int misa_csr_value = 30;
+    asm volatile ("csrw 0x301, %0" : : "r" (misa_csr_value)); // pseudiInstr: csrw csr, rs. baseInst:  csrrw x0, csr, rs 
+
+    //set bits in CSR in offset 0x009 the value 0x1b - should have the value of 0x1f
+    asm volatile ("csrs 0x009, 0x1b");    // pseudoInst: csrsi csr, imm. baseInst: csrrsi x0, csr, imm
+    
+    //clear bits in CSR in offset 0x009 the value 0x4 - should have the value of 0x4
+    asm volatile ("csrc 0x009, 0x1b");    // pseudoInst: csrci csr, imm. baseInst: csrrci x0, csr, imm
+
+    //set CSR in offset 0x301 using value 63 - should have the value of 0x3f
+    int set_misa_csr = 63;
+     asm volatile ("csrs 0x301, %0" : : "r" (set_misa_csr)); // pseudiInstr: csrs csr, rs. baseInst: csrrs x0, csr, rs 
+
+    //clear CSR in offset 0x301 using value 11 - should have the value of 0x14 (use only the first inst with misa)
+    int clear_misa_csr = 11;
+    asm volatile ("csrc 0x301, %0" : : "r" (clear_misa_csr)); // pseudiInstr: csrc csr, rs. baseInst: csrrc x0, csr, rs 
+    return 0;
+}  
+


### PR DESCRIPTION
- Because we dont have ref model for csr's, I created a basic tb without it and tested using ModelSim

```
//------------------------------------------------------------
// Description :
// This program is a basic sanity test for the csr
//------------------------------------------------------------

int main()  {  
 
    //write to CSR in offset 0x009 the value 0x7
    asm volatile ("csrw 0x009, 0x7");   // pseudoInst: csrwi csr, imm. baseInst: csrrw x0, csr, rs

    // read CSR in offset 0x009  - should have the value 7
    int scratchpad_csr_value;
    asm volatile ("csrr %0, 0x009" : "=r" (scratchpad_csr_value));  //pseudoInst: csrr rd, csr. baseInst:  csrrs rd, csr, x0 

    //write to CSR in offset 0x301 the value of 30
    int misa_csr_value = 30;
    asm volatile ("csrw 0x301, %0" : : "r" (misa_csr_value)); // pseudiInstr: csrw csr, rs. baseInst:  csrrw x0, csr, rs 

    //set bits in CSR in offset 0x009 the value 0x1b
    asm volatile ("csrs 0x009, 0x1b");    // pseudoInst: csrsi csr, imm. baseInst: csrrsi x0, csr, imm
    
    //clear bits in CSR in offset 0x009 the value 0x4
    asm volatile ("csrc 0x009, 0x1b");    // pseudoInst: csrci csr, imm. baseInst: csrrci x0, csr, imm

    //set CSR in offset 0x301 using value 63
    int set_misa_csr = 63;
    asm volatile ("csrs 0x301, %0" : : "r" (set_misa_csr)); // pseudiInstr: csrs csr, rs. baseInst: csrrs x0, csr, rs 

    //clear CSR in offset 0x301 using value 11 
    int clear_misa_csr = 11;
    asm volatile ("csrc 0x301, %0" : : "r" (clear_misa_csr)); // pseudiInstr: csrc csr, rs. baseInst: csrrc x0, csr, rs 

    int new_value = 20;
    int previous_value;
    asm volatile ("csrrw %0, 0x009, %1" : "=r" (previous_value) : "r" (new_value));
    asm volatile("csrrw %0, 0x009, %1" : "+r" (previous_value) : "r" (new_value));
    asm volatile ("csrrs %0, 0x009, %1" : "+r" (previous_value) : "r" (new_value));
    asm volatile ("csrrc %0, 0x009, %1" : "+r" (previous_value) : "r" (new_value));
    asm volatile ("csrrwi %0, 0x009, 0x1b" :  : "r" (previous_value));
    asm volatile ("csrrsi %0, 0x009, 0x1b" :  : "r" (previous_value));
    asm volatile ("csrrci %0, 0x009, 0x1b" :  : "r" (previous_value));

    /*** special cases from spec involving x0 ****
    // test them using assemnbly file
    csrwi	vxsat,7
    csrrw	x1,vxsat,x0
    csrwi	vxsat,7
    csrwi	vxsat,0
    **********************************************/
    return 0;
}  
```